### PR TITLE
Rendering order fix, Byte Stream capacity increasing optimization

### DIFF
--- a/src/com/vorono4ka/editor/Editor.java
+++ b/src/com/vorono4ka/editor/Editor.java
@@ -8,6 +8,7 @@ import com.vorono4ka.editor.layout.EditorWindow;
 import com.vorono4ka.editor.layout.UsagesWindow;
 import com.vorono4ka.editor.layout.components.Table;
 import com.vorono4ka.editor.layout.menubar.menus.EditMenu;
+import com.vorono4ka.editor.layout.menubar.menus.FileMenu;
 import com.vorono4ka.editor.layout.panels.info.EditorInfoPanel;
 import com.vorono4ka.editor.layout.panels.info.MovieClipInfoPanel;
 import com.vorono4ka.editor.layout.panels.info.ShapeInfoPanel;
@@ -96,6 +97,9 @@ public class Editor {
             spriteSheet.setBitmaps(swf.getDrawBitmapsOfTexture(i));
             this.spriteSheets.add(spriteSheet);
         }
+
+        FileMenu fileMenu = this.window.getMenubar().getFileMenu();
+        fileMenu.checkCanSave();
     }
 
     public void saveFile(String path) {
@@ -123,6 +127,9 @@ public class Editor {
         this.usagesWindows.clear();
 
         this.spriteSheets.clear();
+
+        FileMenu fileMenu = this.window.getMenubar().getFileMenu();
+        fileMenu.checkCanSave();
 
         EditMenu editMenu = this.window.getMenubar().getEditMenu();
         editMenu.checkPreviousAvailable();

--- a/src/com/vorono4ka/editor/layout/menubar/menus/FileMenu.java
+++ b/src/com/vorono4ka/editor/layout/menubar/menus/FileMenu.java
@@ -12,6 +12,8 @@ import java.awt.event.KeyEvent;
 
 public class FileMenu extends JMenu {
     private final JFrame frame;
+    private final JMenuItem saveButton;
+    private final JMenuItem saveAsButton;
 
     public FileMenu(JFrame frame) {
         super("File");
@@ -23,26 +25,35 @@ public class FileMenu extends JMenu {
         JMenuItem open = new JMenuItem("Open", KeyEvent.VK_O);
         open.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_O, InputEvent.CTRL_DOWN_MASK));
 
-        JMenuItem save = new JMenuItem("Save", KeyEvent.VK_O);
-        save.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
+        this.saveButton = new JMenuItem("Save", KeyEvent.VK_O);
+        this.saveButton.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
 
-        JMenuItem saveAs = new JMenuItem("Save as...", KeyEvent.VK_O);
-        saveAs.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK));
+        this.saveAsButton = new JMenuItem("Save as...", KeyEvent.VK_O);
+        this.saveAsButton.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK | InputEvent.SHIFT_DOWN_MASK));
         JMenuItem close = new JMenuItem("Close", KeyEvent.VK_C);
         JMenuItem exit = new JMenuItem("Exit");
 
         open.addActionListener(this::open);
-        save.addActionListener(this::save);
+        this.saveButton.addActionListener(this::save);
         close.addActionListener(FileMenu::close);
         exit.addActionListener(FileMenu::exit);
 
         this.add(open);
-        this.add(save);
-        this.add(saveAs);
+        this.add(this.saveButton);
+        this.add(this.saveAsButton);
         this.add(close);
 
         this.addSeparator();
         this.add(exit);
+
+        this.checkCanSave();
+    }
+
+    public void checkCanSave() {
+        boolean canSave = Main.editor.getSwf() != null;
+
+        this.saveButton.setEnabled(canSave);
+        this.saveAsButton.setEnabled(canSave);
     }
 
     private void open(ActionEvent e) {

--- a/src/com/vorono4ka/editor/renderer/Batch.java
+++ b/src/com/vorono4ka/editor/renderer/Batch.java
@@ -143,4 +143,11 @@ public class Batch {
     public GLImage getImage() {
         return image;
     }
+
+    @Override
+    public String toString() {
+        return "Batch {" +
+                "textureId=" + this.image.getTextureId() +
+                "}";
+    }
 }

--- a/src/com/vorono4ka/editor/renderer/BatchPool.java
+++ b/src/com/vorono4ka/editor/renderer/BatchPool.java
@@ -1,0 +1,39 @@
+package com.vorono4ka.editor.renderer;
+
+import com.jogamp.opengl.GL3;
+import com.vorono4ka.swf.GLImage;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BatchPool {
+    private final List<Batch> batches;
+
+    public BatchPool() {
+        this.batches = new ArrayList<>();
+    }
+
+    public void pullBatches(List<Batch> batches) {
+        this.batches.addAll(batches);
+    }
+
+    public Batch createOrPopBatch(GL3 gl, GLImage image) {
+        Batch neededBatch = null;
+
+        for (Batch batch : this.batches) {
+            if (batch.getImage() == image) {
+                neededBatch = batch;
+                break;
+            }
+        }
+
+        this.batches.remove(neededBatch);
+
+        if (neededBatch == null) {
+            neededBatch = new Batch(image);
+            neededBatch.init(gl);
+        }
+
+        return neededBatch;
+    }
+}

--- a/src/com/vorono4ka/editor/renderer/Stage.java
+++ b/src/com/vorono4ka/editor/renderer/Stage.java
@@ -101,7 +101,11 @@ public class Stage {
         }
 
         this.gl.glClearColor(.5f, .5f, .5f, 1);
-        this.gl.glClear(GL3.GL_COLOR_BUFFER_BIT);
+        this.gl.glClear(GL3.GL_COLOR_BUFFER_BIT | GL3.GL_DEPTH_BUFFER_BIT | GL3.GL_STENCIL_BUFFER_BIT);
+
+        this.gl.glStencilMask(0xFF);
+        this.gl.glClearStencil(0);
+        this.gl.glStencilMask(0);
 
 //        DisplayObject selectedObject = Main.editor.getSelectedObject();
 //        if (selectedObject == null) return;
@@ -245,8 +249,30 @@ public class Stage {
         this.stageSprite.removeAllChildren();
     }
 
-    public void setStencilRenderingState(int state) {  // TODO
+    public void setStencilRenderingState(int state) {  // TODO: split into separate batch buffer
+        switch (state) {
+            case 1 -> {
+                // scissors
+            }
+            case 2 -> {
+                this.gl.glEnable(GL3.GL_STENCIL_TEST);
+                this.gl.glStencilFunc(GL3.GL_ALWAYS, 1, 0xFF); // каждый фрагмент обновит трафаретный буфер
+                this.gl.glStencilOp(GL3.GL_KEEP, GL3.GL_KEEP, GL3.GL_REPLACE);
+                this.gl.glStencilMask(0xFF); // включить запись в трафаретный буфер
 
+                this.gl.glDepthMask(false);
+                this.gl.glClear(GL3.GL_STENCIL_BUFFER_BIT); // Clear stencil buffer (0 by default)
+            }
+            case 3 -> {
+                this.gl.glStencilFunc(GL3.GL_EQUAL, 1, 0xFF);
+                this.gl.glStencilMask(0x00); // отключить запись в трафаретный буфер
+            }
+            case 4 -> this.gl.glDisable(GL3.GL_STENCIL_TEST);
+            case 5 -> {
+                this.gl.glStencilFunc(GL3.GL_NOTEQUAL, 1, 0xFF);
+                this.gl.glStencilMask(0x00); // отключить запись в трафаретный буфер
+            }
+        }
     }
 
     public int getScaleStep() {

--- a/src/com/vorono4ka/swf/SupercellSWF.java
+++ b/src/com/vorono4ka/swf/SupercellSWF.java
@@ -347,7 +347,7 @@ public class SupercellSWF {
 
         this.saveTags(stream);
 
-        byte[] data = stream.getBuffer();
+        byte[] data = stream.getData();
 
         try {
             data = Compressor.compress(data, 4);

--- a/src/com/vorono4ka/swf/displayObjects/MovieClipModifier.java
+++ b/src/com/vorono4ka/swf/displayObjects/MovieClipModifier.java
@@ -26,7 +26,7 @@ public class MovieClipModifier extends DisplayObject {
             }
         }
 
-        stage.setStencilRenderingState(stencilRenderingState);
+        stage.doInRenderThread(() -> stage.setStencilRenderingState(stencilRenderingState));
 
         return false;
     }

--- a/src/com/vorono4ka/swf/originalObjects/MovieClipOriginal.java
+++ b/src/com/vorono4ka/swf/originalObjects/MovieClipOriginal.java
@@ -172,11 +172,6 @@ public class MovieClipOriginal extends DisplayObjectOriginal {
             stream.writeShort(id);
         }
 
-//        stream.writeShort(this.children.length);
-//        for (DisplayObjectOriginal child : this.children) {
-//            stream.writeShort(child.getId());
-//        }
-
         if (this.tag == Tag.MOVIE_CLIP_3 || this.tag == Tag.MOVIE_CLIP_35) {
             for (byte blend : this.childrenBlends) {
                 stream.writeUnsignedChar(blend);

--- a/src/io/airlift/compress/zstd/ZstdCompressor.java
+++ b/src/io/airlift/compress/zstd/ZstdCompressor.java
@@ -52,7 +52,7 @@ public class ZstdCompressor
         // Java 9+ added an overload of various methods in ByteBuffer. When compiling with Java 11+ and targeting Java 8 bytecode
         // the resulting signatures are invalid for JDK 8, so accesses below result in NoSuchMethodError. Accessing the
         // methods through the interface class works around the problem
-        // Sidenote: we can't target "javac --release 8" because Unsafe is not available in the signature data for that profile
+        // Side note: we can't target "javac --release 8" because Unsafe is not available in the signature data for that profile
         Buffer input = inputBuffer;
         Buffer output = outputBuffer;
 

--- a/src/io/airlift/compress/zstd/ZstdDecompressor.java
+++ b/src/io/airlift/compress/zstd/ZstdDecompressor.java
@@ -46,7 +46,7 @@ public class ZstdDecompressor
         // Java 9+ added an overload of various methods in ByteBuffer. When compiling with Java 11+ and targeting Java 8 bytecode
         // the resulting signatures are invalid for JDK 8, so accesses below result in NoSuchMethodError. Accessing the
         // methods through the interface class works around the problem
-        // Sidenote: we can't target "javac --release 8" because Unsafe is not available in the signature data for that profile
+        // Side note: we can't target "javac --release 8" because Unsafe is not available in the signature data for that profile
         Buffer input = inputBuffer;
         Buffer output = outputBuffer;
 

--- a/src/org/sevenzip/CRC.java
+++ b/src/org/sevenzip/CRC.java
@@ -39,6 +39,6 @@ public class CRC {
 	}
 	
 	public int GetDigest() {
-		return _value ^ (-1);
+		return ~_value;
 	}
 }


### PR DESCRIPTION
Fixed the order of rendering shapes

For example, emojis now look better. 
![emojis comparison](https://user-images.githubusercontent.com/54549682/224488924-eb5e5b05-d4aa-49b3-b668-9b42f563952e.png)
