### PR TITLE
feat: implemented recursive MovieClipModifier (masks) rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea/
+/.vscode/
 /out/
 *.iml
 

--- a/src/main/java/dev/donutquine/editor/renderer/gl/GLRendererContext.java
+++ b/src/main/java/dev/donutquine/editor/renderer/gl/GLRendererContext.java
@@ -17,6 +17,8 @@ public class GLRendererContext implements RendererContext {
     private BlendMode blendMode;
     private boolean blendingEnabled;
 
+    private int stencilRenderingDepth;
+
     public GLRendererContext(GLContext context) {
         this.gl = context;
     }
@@ -45,30 +47,36 @@ public class GLRendererContext implements RendererContext {
     @Override
     public void setRenderStencilState(RenderStencilState state) {
         switch (state) {
-            case NONE -> {}
-            case SCISSORS -> {
-                // TODO:
-            }
             case ENABLED -> {
+                stencilRenderingDepth++;
                 this.gl.glEnable(GLConstants.GL_STENCIL_TEST);
-                this.gl.glStencilFunc(GLConstants.GL_ALWAYS, 1, 0xFF); // каждый фрагмент обновит трафаретный буфер
-                this.gl.glStencilOp(GLConstants.GL_KEEP, GLConstants.GL_KEEP, GLConstants.GL_REPLACE);
-                this.gl.glStencilMask(0xFF); // включить запись в трафаретный буфер
+                this.gl.glStencilFunc(stencilRenderingDepth > 1 ? GLConstants.GL_EQUAL : GLConstants.GL_ALWAYS,
+                        stencilRenderingDepth - 1, 0xFF);
+                this.gl.glStencilOp(GLConstants.GL_KEEP, GLConstants.GL_KEEP, GLConstants.GL_INCR);
+                this.gl.glStencilMask(0xFF);
                 this.gl.glColorMask(false, false, false, false);
-
                 this.gl.glDepthMask(false);
-                this.gl.glClear(GLConstants.GL_STENCIL_BUFFER_BIT); // Clear stencil buffer (0 by default)
             }
             case RENDERING_MASKED -> {
-                this.gl.glStencilFunc(GLConstants.GL_EQUAL, 1, 0xFF);
-                this.gl.glStencilMask(0x00); // отключить запись в трафаретный буфер
                 this.gl.glColorMask(true, true, true, true);
+                if (stencilRenderingDepth != 0) {
+                    this.gl.glStencilFunc(GLConstants.GL_EQUAL, stencilRenderingDepth, 0xFF);
+                    this.gl.glStencilMask(0x00);
+                }
             }
-            case DISABLED -> this.gl.glDisable(GLConstants.GL_STENCIL_TEST);
-            case RENDERING_UNMASKED -> {
-                this.gl.glStencilFunc(GLConstants.GL_NOTEQUAL, 1, 0xFF);
-                this.gl.glStencilMask(0x00); // отключить запись в трафаретный буфер
-                this.gl.glColorMask(true, true, true, true);
+            case DISABLED -> {
+                stencilRenderingDepth--;
+                this.gl.glColorMask(false, false, false, false);
+                if (stencilRenderingDepth != 0) {
+                    this.gl.glStencilFunc(GLConstants.GL_EQUAL, stencilRenderingDepth + 1, 0xFF);
+                    this.gl.glStencilOp(GLConstants.GL_KEEP, GLConstants.GL_KEEP, GLConstants.GL_DECR);
+                    this.gl.glStencilMask(0xFF);
+                } else {
+                    this.gl.glStencilMask(0xFF);
+                    this.gl.glClear(GLConstants.GL_STENCIL_BUFFER_BIT);
+                    this.gl.glStencilMask(0);
+                    this.gl.glDisable(GLConstants.GL_STENCIL_TEST);
+                }
             }
         }
     }
@@ -138,6 +146,8 @@ public class GLRendererContext implements RendererContext {
     public void clearStencil() {
         this.gl.glStencilMask(0xFF);
         this.gl.glClearStencil(0);
+        this.gl.glClear(GLConstants.GL_STENCIL_BUFFER_BIT);
         this.gl.glStencilMask(0);
+        stencilRenderingDepth = 0;
     }
 }

--- a/src/main/java/dev/donutquine/editor/renderer/impl/EditorStage.java
+++ b/src/main/java/dev/donutquine/editor/renderer/impl/EditorStage.java
@@ -1,5 +1,6 @@
 package dev.donutquine.editor.renderer.impl;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.nio.FloatBuffer;
 import java.util.Iterator;
@@ -283,6 +284,15 @@ public class EditorStage implements Stage {
         }
 
         renderer.setStencilRenderingState(shader, state);
+
+        // The drawApi only allows drawing amid rendering display objects,
+        // so screen quad have to be pushed beforehand
+        // The color doesnt matter since the DISABLED state already did
+        // this.gl.glColorMask(false, false, false, false) .
+        if (state == RenderStencilState.DISABLED) {
+            drawApi.drawRectangle(camera.getClipArea(), Color.WHITE);
+            renderer.setStencilRenderingState(shader, RenderStencilState.RENDERING_MASKED);
+        }
     }
 
     @Override


### PR DESCRIPTION
The original MovieClipModifier only supports a single layer of masks, causing rendering flaws compared to thre game engine
does titan support nested siblings mask 
e.g.
Mask 1
    Mask 2
        some content
    end Mask 2
    Mask 3
        some content
    end Mask 3
end Mask 1

the original code do glClear(glStencilBit) when Mask 2 ends, effectively clearing the stencil bits of Mask 1 too, casuing later draws inside Mask 1 to leak out

-------------------------------
The commited code uses GL_INCR and GL_DECR to support multiple depth of mask:
first Mask 1 increments stencilbit of all covered pixels, basically 0->1
```
this.gl.glStencilFunc(GLConstants.GL_ALWAYS, 0, 0xFF);
this.gl.glStencilOp(GLConstants.GL_KEEP, GLConstants.GL_KEEP, GLConstants.GL_INCR);
 this.gl.glStencilMask(0xFF);
```
then Mask 2 increments stencilbit of all covered pixels only when they equal to 1, basically 1->2
```
this.gl.glStencilFunc(GLConstants.GL_EQUALS, 1, 0xFF);
this.gl.glStencilOp(GLConstants.GL_KEEP, GLConstants.GL_KEEP, GLConstants.GL_INCR);
 this.gl.glStencilMask(0xFF);
```
now pixels on screen that are in neither masks are marked with 0, and those inside Mask 1 but outside Mask 2 is marked with 1, and those inside both Mask 1 and Mask 2 are marked with 2

when exiting from Mask 2:
a full screen quad is drawn with
```
this.gl.glStencilFunc(GLConstants.GL_EQUAL,  2, 0xFF);
this.gl.glStencilOp(GLConstants.GL_KEEP, GLConstants.GL_KEEP, GLConstants.GL_DECR);
 this.gl.glStencilMask(0xFF);
```
effectively decrementing all pixel on screen marked with 2 to 1, preserving the Mask 1 shape

although an api to draw quads exist in your code, they are not immediate and instead pushes draw call to batches, therefore a patch in EditorStage is needed to push a full screen quad draw to the batches, everytime Mask End is encountered 

the draw calls always check stencilBit equal to their current depth:
```
this.gl.glStencilFunc(GLConstants.GL_EQUAL, stencilRenderingDepth, 0xFF);
this.gl.glStencilMask(0x00);
```
ensuring correct masking

-----------------------------------
ive tested the code myself and it seems it works well for all kinds of masks ingame now. recurive masks are not uncommon in sc files so you should find it easy to validate yourself.