### PR TITLE
fix: return null if no navigation history

### DIFF
--- a/src/main/java/dev/donutquine/editor/layout/SupercellSWFLayoutController.java
+++ b/src/main/java/dev/donutquine/editor/layout/SupercellSWFLayoutController.java
@@ -101,7 +101,12 @@ public class SupercellSWFLayoutController implements TextureLayoutController<Sup
     }
 
     public DisplayObject getSelectedObject() {
-        return this.assetFile.getById(this.assetFile.getNavigationHistory().getCurrent());
+        NavigationHistory<Integer> navigationHistory = this.assetFile.getNavigationHistory();
+        if (navigationHistory.hasCurrent()) {
+            return this.assetFile.getById(navigationHistory.getCurrent());
+        }
+
+        return null;
     }
 
 	@Override

--- a/src/main/java/dev/donutquine/editor/navigation/NavigationHistory.java
+++ b/src/main/java/dev/donutquine/editor/navigation/NavigationHistory.java
@@ -12,6 +12,10 @@ public class NavigationHistory<T> {
 
     private int historyPosition = -1;
 
+    public boolean hasCurrent() {
+        return this.historyPosition != -1; // or >= 0 && < selectedIds.size()
+    }
+
     public T getCurrent() {
         return this.selectedIds.get(this.historyPosition);
     }


### PR DESCRIPTION
fixes index out of bounds exception when exporting without navigation