### PR TITLE
fix(movieclip): clear selection instead of resetting keyboard actions

### DIFF
--- a/src/main/java/dev/donutquine/editor/layout/panels/info/MovieClipPropertyPanel.java
+++ b/src/main/java/dev/donutquine/editor/layout/panels/info/MovieClipPropertyPanel.java
@@ -111,6 +111,7 @@ public class MovieClipPropertyPanel extends JPanel {
             public void actionPerformed(ActionEvent event) {
                 int firstIndex = table.getSelectedRow();
                 int elementCount = table.getSelectedRowCount();
+                if (elementCount < 1) return;
 
                 try {
                     tableModel.duplicate(firstIndex, elementCount);
@@ -119,7 +120,7 @@ public class MovieClipPropertyPanel extends JPanel {
                 }
 
                 // NOTE: Should we actually reset selection?
-                table.resetKeyboardActions();
+                table.clearSelection();
             }
         };
 


### PR DESCRIPTION
Fixes bug introduced in #248