### PR TITLE
feat: add transparent GIF export

### DIFF
--- a/src/main/java/dev/donutquine/editor/layout/contextmenus/DisplayObjectContextMenu.java
+++ b/src/main/java/dev/donutquine/editor/layout/contextmenus/DisplayObjectContextMenu.java
@@ -120,7 +120,7 @@ public class DisplayObjectContextMenu extends ContextMenu {
                 DisplayObjectOriginal displayObject = swf.getOriginalDisplayObject(displayObjectId, null);
                 exportAsMenu.setEnabled(!(displayObject instanceof TextFieldOriginal));
                 if (displayObject instanceof MovieClipOriginal movieClipOriginal) {
-                    boolean hasMoreThanOneFrame = movieClipOriginal.getFrames().size() > 1;
+                    boolean hasMoreThanOneFrame = MovieClipHelper.getFrameCountRecursive(swf, movieClipOriginal) > 1;
                     exportAsVideoButton.setEnabled(hasMoreThanOneFrame);
                     exportAsGifButton.setEnabled(hasMoreThanOneFrame);
                 } else {

--- a/src/main/java/dev/donutquine/editor/layout/contextmenus/DisplayObjectContextMenu.java
+++ b/src/main/java/dev/donutquine/editor/layout/contextmenus/DisplayObjectContextMenu.java
@@ -23,6 +23,7 @@ import dev.donutquine.editor.renderer.impl.EditorStage;
 import dev.donutquine.editor.renderer.impl.RendererHelper;
 import dev.donutquine.editor.settings.EditorPreferences;
 import dev.donutquine.exporter.FfmpegVideoExporter;
+import dev.donutquine.exporter.GifExporter;
 import dev.donutquine.exporter.VideoExporter;
 import dev.donutquine.exporter.VideoFormat;
 import dev.donutquine.exporter.VideoFormats;
@@ -54,6 +55,7 @@ public class DisplayObjectContextMenu extends ContextMenu {
     private final SupercellSWFLayoutController swfLayoutController;
 
     private final JMenuItem exportAsVideoButton;
+    private final JMenuItem exportAsGifButton;
     private final JMenu exportAsMenu;
 
     private EditorPreferences preferences;
@@ -84,6 +86,9 @@ public class DisplayObjectContextMenu extends ContextMenu {
 
         exportAsVideoButton = this.add(exportAsMenu, "Export as video", KeyEvent.VK_V);
         exportAsVideoButton.addActionListener(this::exportAsVideoCallback);
+
+        exportAsGifButton = this.add(exportAsMenu, "Export as GIF", KeyEvent.VK_G);
+        exportAsGifButton.addActionListener(this::exportAsGifCallback);
 
         this.addSeparator();
 
@@ -117,14 +122,17 @@ public class DisplayObjectContextMenu extends ContextMenu {
                 if (displayObject instanceof MovieClipOriginal movieClipOriginal) {
                     boolean hasMoreThanOneFrame = movieClipOriginal.getFrames().size() > 1;
                     exportAsVideoButton.setEnabled(hasMoreThanOneFrame);
+                    exportAsGifButton.setEnabled(hasMoreThanOneFrame);
                 } else {
                     exportAsVideoButton.setEnabled(false);
+                    exportAsGifButton.setEnabled(false);
                 }
             } catch (UnableToFindObjectException e) {
                 throw new RuntimeException(e);
             }
         } else {
             exportAsMenu.setEnabled(false);
+            exportAsGifButton.setEnabled(false);
         }
     }
 
@@ -234,6 +242,13 @@ public class DisplayObjectContextMenu extends ContextMenu {
         fileChooser.addChoosableFileFilter(new FileNameExtensionFilter("AV1 video", "avi"));
         fileChooser.addChoosableFileFilter(new FileNameExtensionFilter("MP4 video (no transparency)", "mp4"));
 
+        MovieClip movieClip = (MovieClip) getRenderableObject(displayObjectId);
+        String exportName = movieClip.getExportName();
+        if (exportName != null) {
+            java.io.File currentDir = fileChooser.getCurrentDirectory();
+            fileChooser.setSelectedFile(new java.io.File(currentDir, exportName));
+        }
+
         int result = fileChooser.showSaveDialog(swfLayoutController.window.getFrame());
         if (result != SystemFileChooser.APPROVE_OPTION) return;
 
@@ -250,6 +265,129 @@ public class DisplayObjectContextMenu extends ContextMenu {
         exportAsVideo(path, (MovieClip) getRenderableObject(displayObjectId), format);
 
         RendererHelper.rollbackRenderer(stage, viewport);
+    }
+
+    private void exportAsGifCallback(ActionEvent actionEvent) {
+        if (this.table.getSelectedRowCount() == 0) return;
+
+        int displayObjectId = getDisplayObjectId(this.table.getSelectedRow());
+
+        EditorStage stage = EditorStage.getInstance();
+        ReadonlyRect viewport = stage.getCamera().getViewport();
+
+        SystemFileChooser fileChooser = new SystemFileChooser();
+        fileChooser.setStateStoreID("exportGif");
+        fileChooser.setFileSelectionMode(SystemFileChooser.FILES_ONLY);
+        fileChooser.setMultiSelectionEnabled(false);
+        fileChooser.addChoosableFileFilter(new FileNameExtensionFilter("GIF animation (transparent)", "gif"));
+
+        MovieClip movieClip = (MovieClip) getRenderableObject(displayObjectId);
+        String exportName = movieClip.getExportName();
+        if (exportName != null) {
+            java.io.File currentDir = fileChooser.getCurrentDirectory();
+            fileChooser.setSelectedFile(new java.io.File(currentDir, exportName));
+        }
+
+        int result = fileChooser.showSaveDialog(swfLayoutController.window.getFrame());
+        if (result != SystemFileChooser.APPROVE_OPTION) return;
+
+        Path path = SystemFileChooserUtil.getPathWithExtension(fileChooser, "gif");
+        if (path == null) return;
+
+        // GIF frame delays are stored in centiseconds (1/100s).
+        // To avoid rounding errors, pick the highest fps that evenly divides 100
+        // and does not exceed the source fps.  e.g. 60fps src -> 50fps GIF (exact 2cs/frame).
+        int srcFps = movieClip.getFps();
+        int defaultFps = 1;
+        for (int candidate : new int[]{100, 50, 25, 20, 10, 5, 4, 2, 1}) {
+            if (candidate <= srcFps) {
+                defaultFps = candidate;
+                break;
+            }
+        }
+        String input = javax.swing.JOptionPane.showInputDialog(
+            swfLayoutController.window.getFrame(),
+            "GIF frame rate (fps):\n"
+                + "Original: " + srcFps + " fps\n"
+                + "Recommended: " + defaultFps + " fps  (largest value that divides 100 evenly → no timing error)\n"
+                + "Note: GIF delays are in 1/100s; non-divisors cause speed drift.",
+            String.valueOf(defaultFps)
+        );
+        // Pre-fill by replacing the empty dialog return with defaultFps
+        if (input == null) {
+            RendererHelper.rollbackRenderer(stage, viewport);
+            return; // cancelled
+        }
+        input = input.trim();
+        int gifFps;
+        try {
+            gifFps = Integer.parseInt(input.isEmpty() ? String.valueOf(defaultFps) : input);
+            if (gifFps <= 0) throw new NumberFormatException();
+        } catch (NumberFormatException e) {
+            swfLayoutController.window.showErrorDialog("Invalid frame rate: \"" + input + "\"");
+            RendererHelper.rollbackRenderer(stage, viewport);
+            return;
+        }
+
+        exportAsGif(path, movieClip, gifFps);
+
+        RendererHelper.rollbackRenderer(stage, viewport);
+    }
+
+
+    private void exportAsGif(Path path, MovieClip movieClip, int gifFps) {
+        EditorStage stage = EditorStage.getInstance();
+
+        Rect bounds = getRenderBounds(stage.calculateBoundsForAllFrames(movieClip));
+
+        float pixelSize = this.preferences.getPixelSize();
+        bounds.scale(pixelSize);
+
+        ReadonlyRect ceilBounds = roundBounds(bounds, false);
+
+        Matrix2x3 matrix = new Matrix2x3();
+        matrix.scaleMultiply(pixelSize, pixelSize);
+
+        ColorTransform colorTransform = new ColorTransform();
+
+        MovieClipState state = movieClip.getState();
+        int loopFrame = movieClip.getLoopFrame();
+        int startFrame = movieClip.getCurrentFrame();
+
+        stage.doInRenderThread(() -> {
+            Framebuffer framebuffer = RendererHelper.prepareStageForRendering(stage, ceilBounds);
+
+            boolean parentSet = false;
+            if (movieClip.getParent() == null) {
+                movieClip.setParent(stage.getStageSprite());
+                parentSet = true;
+            }
+
+            try (GifExporter gifExporter = new GifExporter(path, gifFps, gifFps)) {
+                MovieClipHelper.doForAllFrames(movieClip, (frameIndex) -> {
+                    movieClip.gotoAbsoluteTimeRecursive(frameIndex * movieClip.getMsPerFrame());
+                    if (loopFrame != -1) {
+                        movieClip.setFrame(loopFrame);
+                    } else if (state == MovieClipState.STOPPED) {
+                        movieClip.setFrame(startFrame);
+                    }
+
+                    movieClip.render(matrix, colorTransform, 0, 0);
+                    stage.renderToFramebuffer(framebuffer);
+
+                    BufferedImage image = ImageUtils.createBufferedImageFromPixels(
+                        framebuffer.getWidth(), framebuffer.getHeight(),
+                        framebuffer.getPixelArray(true), false);
+                    gifExporter.encodeFrame(image, frameIndex);
+                });
+            }
+
+            if (parentSet) {
+                movieClip.setParent(null);
+            }
+
+            framebuffer.delete();
+        });
     }
 
     private DisplayObject getRenderableObject(int displayObjectId) {
@@ -429,7 +567,9 @@ public class DisplayObjectContextMenu extends ContextMenu {
                     frameName = String.join("-", frameName, frameLabel);
                 }
 
-                return Path.of(addPixelSizeToFilename(String.valueOf(displayObject.getId()), pixelSize), frameName + ".png");
+                String exportName = movieClip.getExportName();
+                String folderName = exportName != null ? exportName : String.valueOf(displayObject.getId());
+                return Path.of(addPixelSizeToFilename(folderName, pixelSize), frameName + ".png");
             }
 
             String exportName = movieClip.getExportName();

--- a/src/main/java/dev/donutquine/exporter/GifExporter.java
+++ b/src/main/java/dev/donutquine/exporter/GifExporter.java
@@ -1,0 +1,113 @@
+package dev.donutquine.exporter;
+
+import dev.donutquine.utilities.ImageUtils;
+import dev.donutquine.utilities.SystemUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.stream.Stream;
+
+/**
+ * Exports animation frames as a transparent-background GIF using ffmpeg's palette-based approach.
+ * GIF transparency is binary (on/off per pixel); pixels with alpha < 128 become transparent.
+ *
+ * @param sourceFps  frame rate at which frames are fed in (original animation fps)
+ * @param outputFps  desired GIF playback frame rate; ffmpeg will resample if different from sourceFps
+ */
+public class GifExporter implements VideoExporter {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GifExporter.class);
+
+    private final Path filepath;
+    private final int sourceFps;
+    private final int outputFps;
+    private final Path framesDirectory;
+
+    private boolean isClosed;
+
+    public GifExporter(Path path, int sourceFps, int outputFps) {
+        this.sourceFps = sourceFps;
+        this.outputFps = outputFps;
+        this.filepath = path;
+        this.framesDirectory = path.getParent().resolve(path.getFileName().toString() + "_frames");
+        if (this.framesDirectory.toFile().exists()) {
+            try (Stream<Path> files = Files.walk(this.framesDirectory)) {
+                files.sorted(Comparator.reverseOrder())
+                     .filter(p -> !p.equals(this.framesDirectory))
+                     .map(Path::toFile)
+                     .forEach(File::delete);
+            } catch (IOException e) {
+                LOGGER.error("Failed to clean frames directory", e);
+            }
+        }
+        this.framesDirectory.toFile().mkdirs();
+    }
+
+    @Override
+    public void encodeFrame(BufferedImage image, int frameIndex) {
+        Path framePath = this.framesDirectory.resolve(frameIndex + ".png");
+        ImageUtils.saveImage(framePath, image);
+    }
+
+    @Override
+    public void close() {
+        if (isClosed) return;
+
+        // fps={outputFps}                    → resample to target fps (handles slowdown / skip)
+        // palettegen=reserve_transparent=on  → include transparent entry in palette
+        // paletteuse alpha_threshold=128     → pixels with alpha < 128 map to transparent
+        // -loop 0                            → infinite loop
+        final String filterComplex;
+        String baseFilter = "split[v][p];" +
+            "[p]palettegen=reserve_transparent=on[palette];" +
+            "[v][palette]paletteuse=dither=sierra2_4a:alpha_threshold=128";
+        if (sourceFps != outputFps) {
+            filterComplex = "fps=" + outputFps + "," + baseFilter;
+        } else {
+            filterComplex = baseFilter;
+        }
+
+        SystemUtils.waitProcessInSwing(
+            () -> SystemUtils.runProcess(
+                "ffmpeg",
+                "-y",
+                "-hide_banner",
+                "-loglevel", "panic",
+                "-framerate", sourceFps,
+                "-i", framesDirectory.resolve("%d.png").toAbsolutePath(),
+                "-filter_complex", filterComplex,
+                "-loop", 0,
+                filepath.toAbsolutePath()
+            ),
+            (process) -> LOGGER.info("Waiting for ffmpeg to encode transparent GIF ({} fps -> {} fps)...", sourceFps, outputFps),
+            (process) -> {
+                LOGGER.info("ffmpeg finished GIF encoding with code: {}", process.exitValue());
+
+                if (process.exitValue() != 0) {
+                    try {
+                        String errorOutput = new String(process.getErrorStream().readAllBytes());
+                        if (!errorOutput.isEmpty()) {
+                            LOGGER.error(errorOutput);
+                        }
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    return;
+                }
+
+                try (Stream<Path> files = Files.walk(framesDirectory)) {
+                    files.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        );
+
+        isClosed = true;
+    }
+}

--- a/src/main/java/dev/donutquine/utilities/MovieClipHelper.java
+++ b/src/main/java/dev/donutquine/utilities/MovieClipHelper.java
@@ -6,8 +6,12 @@ import dev.donutquine.swf.movieclips.MovieClipState;
 public final class MovieClipHelper {
     public static void doForAllFrames(MovieClip movieClip, MovieClipFrameIndexConsumer consumer) {
         // TODO: add an ability to choose it by yourself
-//        int maxFrames = movieClip.getFrames().size();
-        int maxFrames = movieClip.getFrameCountRecursive();
+        int maxFrames;
+        if (movieClip.getFrameCount() > 1) {
+            maxFrames = movieClip.getFrameCount();
+        } else {
+            maxFrames = movieClip.getFrameCountRecursive();
+        }
 
         int currentFrame = movieClip.getCurrentFrame();
         int loopFrame = movieClip.getLoopFrame();

--- a/src/main/java/dev/donutquine/utilities/MovieClipHelper.java
+++ b/src/main/java/dev/donutquine/utilities/MovieClipHelper.java
@@ -1,6 +1,11 @@
 package dev.donutquine.utilities;
 
 import dev.donutquine.renderer.impl.swf.objects.MovieClip;
+import dev.donutquine.swf.DisplayObjectOriginal;
+import dev.donutquine.swf.SupercellSWF;
+import dev.donutquine.swf.exceptions.UnableToFindObjectException;
+import dev.donutquine.swf.movieclips.MovieClipChild;
+import dev.donutquine.swf.movieclips.MovieClipOriginal;
 import dev.donutquine.swf.movieclips.MovieClipState;
 
 public final class MovieClipHelper {
@@ -30,6 +35,22 @@ public final class MovieClipHelper {
 
         movieClip.resetTimelinePositionRecursive();
         movieClip.gotoAndPlayFrameIndex(currentFrame, loopFrame, state);
+    }
+
+    public static int getFrameCountRecursive(SupercellSWF swf, MovieClipOriginal movieClip) throws UnableToFindObjectException {
+        int frameCount = movieClip.getFrames().size();
+
+        for (MovieClipChild timelineChild : movieClip.getChildren()) {
+            DisplayObjectOriginal displayObject = swf.getOriginalDisplayObject(timelineChild.id(), movieClip.getExportName());
+            if (displayObject instanceof MovieClipOriginal childMovieClip) {
+                int childFrameCount = MovieClipHelper.getFrameCountRecursive(swf, childMovieClip);
+                if (childFrameCount > frameCount) {
+                    frameCount = childFrameCount;
+                }
+            }
+        }
+
+        return frameCount;
     }
 
     @FunctionalInterface


### PR DESCRIPTION
## Summary

- add transparent GIF export using FFmpeg palette generation
- allow selecting a timing-safe GIF frame rate
- use export names as default filenames and output folders
- clean stale temporary frames before encoding
- avoid duplicate frame-rate conversion
- correct frame iteration for nested movie clips

## Testing

- Manually tested