### PR TITLE
feat: make TextField placeholders toggleable

### DIFF
--- a/src/main/java/dev/donutquine/editor/layout/SupercellSWFLayoutController.java
+++ b/src/main/java/dev/donutquine/editor/layout/SupercellSWFLayoutController.java
@@ -24,6 +24,7 @@ import dev.donutquine.editor.renderer.impl.EditorStage;
 import dev.donutquine.renderer.impl.swf.objects.DisplayObject;
 import dev.donutquine.renderer.impl.swf.objects.MovieClip;
 import dev.donutquine.renderer.impl.swf.objects.Shape;
+import dev.donutquine.renderer.impl.swf.objects.TextField;
 import dev.donutquine.swf.SupercellSWF;
 import dev.donutquine.swf.exceptions.UnableToFindObjectException;
 import dev.donutquine.swf.movieclips.MovieClipOriginal;
@@ -198,6 +199,9 @@ public class SupercellSWFLayoutController implements TextureLayoutController<Sup
         } else {
             this.timelinePanel.setVisible(false);
         }
+
+        // Reset TextField placeholder visibility when switching objects
+        TextField.showPlaceholders = false;
 
         this.currentObjectInfoPanel.setPanel(createPropertiesPanel(displayObject));
 

--- a/src/main/java/dev/donutquine/editor/layout/panels/info/MovieClipPropertyPanel.java
+++ b/src/main/java/dev/donutquine/editor/layout/panels/info/MovieClipPropertyPanel.java
@@ -12,6 +12,7 @@ import javax.swing.ActionMap;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.DropMode;
+import javax.swing.JCheckBox;
 import javax.swing.InputMap;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -36,6 +37,7 @@ import dev.donutquine.editor.layout.shortcut.KeyboardUtils;
 import dev.donutquine.editor.renderer.BlendMode;
 import dev.donutquine.renderer.impl.swf.objects.DisplayObject;
 import dev.donutquine.renderer.impl.swf.objects.MovieClip;
+import dev.donutquine.renderer.impl.swf.objects.TextField;
 import dev.donutquine.swf.ScMatrixBank;
 import dev.donutquine.swf.movieclips.MovieClipFrame;
 
@@ -95,6 +97,10 @@ public class MovieClipPropertyPanel extends JPanel {
         );
 
         this.textInfoPanel.setLayout(new BoxLayout(this.textInfoPanel, BoxLayout.Y_AXIS));
+
+        JCheckBox showTextFieldsCheckbox = new JCheckBox("Show TextField placeholders", TextField.showPlaceholders);
+        showTextFieldsCheckbox.addActionListener(e -> TextField.showPlaceholders = showTextFieldsCheckbox.isSelected());
+        this.textInfoPanel.add(showTextFieldsCheckbox);
 
         this.add(new JScrollPane(this.timelineChildrenTable), "Children");
         this.add(new JScrollPane(this.framesTable), "Frames");

--- a/src/main/java/dev/donutquine/renderer/impl/swf/objects/TextField.java
+++ b/src/main/java/dev/donutquine/renderer/impl/swf/objects/TextField.java
@@ -13,6 +13,7 @@ import java.awt.*;
 public class TextField extends DisplayObject {
     /** Whether to render TextField placeholder rectangles. Defaults to false since there is no font renderer. */
     public static boolean showPlaceholders = false;
+    
     private boolean isInteractive;
     private float cursorBlinkTime;
     private Rect bounds;

--- a/src/main/java/dev/donutquine/renderer/impl/swf/objects/TextField.java
+++ b/src/main/java/dev/donutquine/renderer/impl/swf/objects/TextField.java
@@ -11,6 +11,8 @@ import dev.donutquine.utilities.RenderConfig;
 import java.awt.*;
 
 public class TextField extends DisplayObject {
+    /** Whether to render TextField placeholder rectangles. Defaults to false since there is no font renderer. */
+    public static boolean showPlaceholders = false;
     private boolean isInteractive;
     private float cursorBlinkTime;
     private Rect bounds;
@@ -48,6 +50,8 @@ public class TextField extends DisplayObject {
     }
 
     private boolean shapeRender(Stage stage, Matrix2x3 matrix, ColorTransform colorTransform, int renderConfigBits, boolean noBounds) {
+        if (!showPlaceholders) return false;
+
         Rect transformedBounds = new Rect(
             matrix.applyX(bounds.getLeft(), bounds.getTop()),
             matrix.applyY(bounds.getLeft(), bounds.getTop()),
@@ -58,7 +62,7 @@ public class TextField extends DisplayObject {
         if (stage.startShape(transformedBounds, null, renderConfigBits)) {
             DrawApi drawApi = stage.getDrawApi();
             Color color = new Color(colorTransform.getRedMultiplier(), colorTransform.getGreenMultiplier(), colorTransform.getBlueMultiplier(), colorTransform.getAlpha() / 2);
-            // drawApi.drawRectangleLines(transformedBounds, color, 1);
+            drawApi.drawRectangleLines(transformedBounds, color, 1);
             return true;
         }
 


### PR DESCRIPTION
## Summary

- hide TextField placeholder rectangles by default
- add a MovieClip property checkbox to toggle placeholder visibility
- reset placeholder visibility when switching objects
- render placeholder outlines only when explicitly enabled

## Testing

- Manually tested