### PR TITLE
feat: support Ctrl+scroll zoom

### DIFF
--- a/src/main/java/dev/donutquine/editor/renderer/impl/listeners/MouseWheelListener.java
+++ b/src/main/java/dev/donutquine/editor/renderer/impl/listeners/MouseWheelListener.java
@@ -19,7 +19,7 @@ public class MouseWheelListener implements java.awt.event.MouseWheelListener {
 
         int modifiersEx = e.getModifiersEx();
         int wheelRotation = e.getWheelRotation();
-        if ((modifiersEx & InputEvent.ALT_DOWN_MASK) != 0) {
+        if ((modifiersEx & InputEvent.CTRL_DOWN_MASK) != 0 || (modifiersEx & InputEvent.ALT_DOWN_MASK) != 0) {
             int deltaStep = wheelRotation * SENSITIVE;
             int step = zoom.getScaleStep() - deltaStep;
             if (step < 0) return;


### PR DESCRIPTION
## Summary

- support Ctrl+scroll for editor zoom
- preserve the existing Alt+scroll zoom shortcut

## Testing

- Manually tested